### PR TITLE
Remove hash polyfill, bumper ember-tether

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-babel": "^6.3.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "^7.0.0",
-    "ember-tether": "^0.4.1"
+    "ember-tether": "^1.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "ember-cli-babel": "^6.3.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "^7.0.0",
-    "ember-hash-helper-polyfill": "^0.1.1",
     "ember-tether": "^0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
```
DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version 5.2.8 located: working-title-ui -> ember-tooltips -> ember-hash-helper-polyfill -> ember-cli-babel
DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version 5.2.8 located: working-title-ui -> ember-tooltips -> ember-tether -> ember-cli-babel
```